### PR TITLE
No need for custom gh token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
     - name: 🙋 Open Pull Request
       if: steps.add.outputs.continue
       env:
-        GH_TOKEN: ${{ secrets.RELEASE_PR_GITHUB_TOKEN }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh pr create -f -l release
 


### PR DESCRIPTION
Workflows can be triggered by closing and reopening PRs
