### PR TITLE
Reinsert yarn version decline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,14 @@ jobs:
         fi
         echo "continue=true" >> $GITHUB_OUTPUT
 
+    - name: 🔧️ Fix Prerelease
+      # When committing the package.json, we don't want this to result in a failed `yarn version check`
+      # See https://github.com/yarnpkg/berry/issues/2569
+      if: steps.add.outputs.continue && inputs.release_type == 'prerelease'
+      run: |
+        yarn workspace remix-google-cloud-functions version decline -d
+        git add -A
+
     - name: 🔀 Create Branch
       if: steps.add.outputs.continue
       run: git checkout -b ${{ steps.version.outputs.branch }}


### PR DESCRIPTION
Seems it is still needed when opening a prerelease pr

https://github.com/penx/remix-google-cloud-functions/actions/runs/4108900846/jobs/7090121402
