### PR TITLE
Ignore package.json during version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,14 +66,6 @@ jobs:
         fi
         echo "continue=true" >> $GITHUB_OUTPUT
 
-    - name: 🔧️ Fix Prerelease
-      # When committing the package.json, we don't want this to result in a failed `yarn version check`
-      # See https://github.com/yarnpkg/berry/issues/2569
-      if: steps.add.outputs.continue && inputs.release_type == 'prerelease'
-      run: |
-        yarn workspace remix-google-cloud-functions version decline -d
-        git add -A
-
     - name: 🔀 Create Branch
       if: steps.add.outputs.continue
       run: git checkout -b ${{ steps.version.outputs.branch }}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,3 +7,5 @@ plugins:
     spec: "@yarnpkg/plugin-workspace-tools"
 
 yarnPath: .yarn/releases/yarn-3.4.1.cjs
+changesetIgnorePatterns:
+  - "**/package.json"


### PR DESCRIPTION
Even though changes to package.json could mean a version bump is needed, unless we do this:

- dependabot PRs don't pass the version check
- prerelease PRs don't pass the version check
- release PRs complain about multiple version files

so I think it's the only solution for now

https://github.com/yarnpkg/berry/issues/2569
https://github.com/yarnpkg/berry/issues/4510
